### PR TITLE
add escape underscore rule

### DIFF
--- a/syntax/octopress.vim
+++ b/syntax/octopress.vim
@@ -47,6 +47,8 @@ syn match octopressPullquote /\m{"\s[^{]\+\s"}/ contained oneline
 " Backtick block
 syn region octopressBacktickBlock matchgroup=octopressBacktickBlockDelimiter start=/\m^```\(\s*\|\s\+.*\)$/ end=/\m^```\s*$/
 
+syn match octopressEscape /\\[][\\`*_{}()#+.!-]/
+
 command -nargs=+ HiLink hi def link <args>
 
 HiLink  octopressYamlFrontMatter        PreProc
@@ -61,6 +63,8 @@ HiLink  octopressPullquote              PreProc
 
 HiLink  octopressBacktickBlockDelimiter PreProc
 HiLink  octopressBacktickBlock          Underlined
+
+HiLink  octopressEscape                 Special
 
 delcommand HiLink
 


### PR DESCRIPTION
When I use underscore`_` ,  syntax hilight is not work. like this.

![](https://github.com/glidenote/images2/raw/gh-pages/2012/04/vim-octopress0.png)

so, I add rule, escape underscore and special characters ([][\`*_{}()#+.!-]).

![](https://github.com/glidenote/images2/raw/gh-pages/2012/04/vim-octopress1.png)
